### PR TITLE
[fix] Changed browser target to fix BigInt crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,11 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "chrome >= 67",
+      "edge >= 79",
+      "firefox >= 68",
+      "opera >= 54",
+      "safari >= 14"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
## Summary

In production, there was a crash with the following error: `Uncaught TypeError: Cannot convert a BigInt value to a number`

The fix was related to browser support and web3.js, it was fixed according to this web3 issue: https://github.com/web3/web3.js/issues/6187